### PR TITLE
fix: bad sha256

### DIFF
--- a/Formula/replibyte.rb
+++ b/Formula/replibyte.rb
@@ -3,7 +3,7 @@ class Replibyte < Formula
   desc "Seed Your Development Database With Real Data ⚡️"
   homepage "https://github.com/Qovery/replibyte"
   url "https://github.com/Qovery/replibyte/releases/download/v0.7.2/replibyte_v0.7.2_x86_64-apple-darwin.zip"
-  sha256 "846954148a6a1cd767c4bfe767aaf38670cb04069c8526704864df41bf6fb7cc"
+  sha256 "548d5e44f5d189f1ed3c6084fbaadb24b8fd58767897968f50213ea678def012"
   license "MIT"
 
   def install


### PR DESCRIPTION
Hello,

According brew, there is an issue with the sha265 of the version 0.7.2 when upgrading.

```
==> Downloading https://github.com/Qovery/replibyte/releases/download/v0.7.2/replibyte_v
==> Downloading from https://objects.githubusercontent.com/github-production-release-ass
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 846954148a6a1cd767c4bfe767aaf38670cb04069c8526704864df41bf6fb7cc
  Actual: 548d5e44f5d189f1ed3c6084fbaadb24b8fd58767897968f50213ea678def012
    File: /Users/Tchoupinax/Library/Caches/Homebrew/downloads/3075d943825b225bb647d26964515cda67d111e9bbcda0bf8da10fa1d64c2bb9--replibyte_v0.7.2_x86_64-apple-darwin.zip
To retry an incomplete download, remove the file above.
```

I think it is a mistake but maybe we have to ensure there is not security issue.

Anyway, the fix is ready here :)

Thanks you for your work!
Have a nice day,